### PR TITLE
Added fix for WebGL InworldWebSockClient OnDestroy

### DIFF
--- a/Runtime/Scripts/InworldWebSocketClient.cs
+++ b/Runtime/Scripts/InworldWebSocketClient.cs
@@ -331,9 +331,9 @@ namespace Inworld
         void OnDestroy()
         {
 #if !UNITY_WEBGL || UNITY_EDITOR
-            GameObject webSocketManagerGO = GameObject.Find("/[UnityWebSocket]");
-            if(webSocketManagerGO)
-                Destroy(webSocketManagerGO);
+            var webSocketManager = FindObjectOfType<WebSocketManager>();
+            if(webSocketManager)
+                Destroy(webSocketManager.gameObject);
 #endif
         }
     }

--- a/Runtime/Scripts/InworldWebSocketClient.cs
+++ b/Runtime/Scripts/InworldWebSocketClient.cs
@@ -330,8 +330,11 @@ namespace Inworld
         
         void OnDestroy()
         {
-            if(WebSocketManager.Instance)
-                Destroy(WebSocketManager.Instance.gameObject);
+#if !UNITY_WEBGL || UNITY_EDITOR
+            GameObject webSocketManagerGO = GameObject.Find("/[UnityWebSocket]");
+            if(webSocketManagerGO)
+                Destroy(webSocketManagerGO);
+#endif
         }
     }
 }


### PR DESCRIPTION
Moved back to GameObject.Find implementation to match WebSocketManager and avoid creating an instance in the event one does not exist.

```       
public static WebSocketManager Instance
{
    get
    {
        if (!_instance) 
            CreateInstance();
        return _instance;
    }
}
```

```
public static void CreateInstance()
{
    GameObject go = GameObject.Find("/" + rootName);
    if (!go) go = new GameObject(rootName);
    _instance = go.GetComponent<WebSocketManager>();
    if (!_instance) 
        _instance = go.AddComponent<WebSocketManager>();
}
```